### PR TITLE
KAN-71 Adjust Category Service and use MSSQL

### DIFF
--- a/Common/Models/BaseDbModel.cs
+++ b/Common/Models/BaseDbModel.cs
@@ -11,9 +11,8 @@ namespace Common.Models
     /// <summary>
     /// A base DB model shared across all Base DB models
     /// </summary>
-    public class BaseDbModel : BaseModel
+    public class BaseDbModel
     {
-        [PrimaryKey("Id", false)]
         public int Id { get; set; }
     }
 }

--- a/Common/Models/Category/Category.cs
+++ b/Common/Models/Category/Category.cs
@@ -12,19 +12,16 @@ namespace Common.Models.Category
     /// <summary>
     /// Represents a Category DB Entity
     /// </summary>
-    [Table("Categories")]
     public class Category : BaseDbModel
     {
         /// <summary>
         /// Represents a <see cref="CategoryType"/>'s Id
         /// </summary>
-        [Column("CategoryTypeId")]
-        public int TypeId { get; set; }
+        public int CategoryTypeId { get; set; }
 
         /// <summary>
         /// An actual string representation of a <see cref="Category"/>
         /// </summary>
-        [Column("Value")]
         public string Value { get; set; }
     }
 }

--- a/Common/Models/Category/CategoryType.cs
+++ b/Common/Models/Category/CategoryType.cs
@@ -13,13 +13,11 @@ namespace Common.Models.Category
     /// <summary>
     /// Represents a Category Type Entity
     /// </summary>
-    [Table("CategoriesTypes")]
     public class CategoryType : BaseDbModel
     {
         /// <summary>
         /// Integer representation of a <see cref="CategoryType"/>
         /// </summary>
-        [Column("Value")]
         public string Value { get; set; }
     }
 }

--- a/Services/CategoryService/CategoryService.csproj
+++ b/Services/CategoryService/CategoryService.csproj
@@ -8,7 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="supabase-csharp" Version="0.16.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/Services/CategoryService/Controllers/CategoryController.cs
+++ b/Services/CategoryService/Controllers/CategoryController.cs
@@ -11,9 +11,9 @@ namespace UsersService.Controllers
     [ApiController]
     public class CategoryController : ControllerBase
     {
-        private readonly IDbService<Category> _dbService;
+        private readonly IDbService _dbService;
 
-        public CategoryController(IDbService<Category> dbService)
+        public CategoryController(IDbService dbService)
         {
             _dbService = dbService;
         }
@@ -30,7 +30,7 @@ namespace UsersService.Controllers
 
             try
             {
-                var categories = await _dbService.GetAllAsync();
+                var categories = await _dbService.GetAllCategories();
                 res.Data = categories;
                 res.Status = EHttpStatus.OK;
             }
@@ -62,7 +62,7 @@ namespace UsersService.Controllers
 
             try
             {
-                var categories = await _dbService.GetByCategoryAsync(id);
+                var categories = await _dbService.GetCategoriesByCategoryType(id);
                 res.Data = categories;
                 res.Status = EHttpStatus.OK;
             }
@@ -95,7 +95,7 @@ namespace UsersService.Controllers
 
             try
             {
-                var category = await _dbService.GetAsync(id);
+                Category category = await _dbService.GetCategory(id);
                 res.Data = category;
                 res.Status = EHttpStatus.OK;
             }

--- a/Services/CategoryService/Controllers/CategoryTypeController.cs
+++ b/Services/CategoryService/Controllers/CategoryTypeController.cs
@@ -12,9 +12,9 @@ namespace UsersService.Controllers
     [ApiController]
     public class CategoryTypeController : ControllerBase
     {
-        private readonly IDbService<CategoryType> _dbService;
+        private readonly IDbService _dbService;
 
-        public CategoryTypeController(IDbService<CategoryType> dbService)
+        public CategoryTypeController(IDbService dbService)
         {
             _dbService = dbService;
         }
@@ -31,7 +31,7 @@ namespace UsersService.Controllers
 
             try
             {
-                var categoryTypes = await _dbService.GetAllAsync();
+                List<CategoryType> categoryTypes = await _dbService.GetAllCategoryTypes();
                 res.Data = categoryTypes;
                 res.Status = EHttpStatus.OK;
             }
@@ -64,8 +64,8 @@ namespace UsersService.Controllers
 
             try
             {
-                var category = await _dbService.GetAsync(id);
-                res.Data = category;
+                CategoryType categoryType = await _dbService.GetCategoryType(id);
+                res.Data = categoryType;
                 res.Status = EHttpStatus.OK;
             }
             catch (NotFoundException ex)

--- a/Services/CategoryService/Db/DataContext.cs
+++ b/Services/CategoryService/Db/DataContext.cs
@@ -1,0 +1,24 @@
+﻿using Common.Models.Category;
+using Microsoft.EntityFrameworkCore;
+
+namespace CategoryService.Db
+{
+    /// <summary>
+    /// Represents the data context for the category service.
+    /// </summary>
+    public class DataContext : DbContext
+    {
+        public DataContext(DbContextOptions<DataContext> options)
+            : base(options) { }
+
+        /// <summary>
+        /// Gets or sets the categories DbSet.
+        /// </summary>
+        public virtual DbSet<Category> Categories { get; set; }
+
+        /// <summary>
+        /// Gets or sets the category types DbSet.
+        /// </summary>
+        public virtual DbSet<CategoryType> CategoriesTypes { get; set; }
+    }
+}

--- a/Services/CategoryService/Db/DbService.cs
+++ b/Services/CategoryService/Db/DbService.cs
@@ -1,61 +1,89 @@
-﻿using Common.Enums;
+﻿using CategoryService.Db;
+using Common.Enums;
 using Common.Exceptions;
 using Common.Models;
 using Common.Models.Category;
+using Microsoft.EntityFrameworkCore;
 using Supabase;
 
 namespace CategoryService.Service
 {
-    public class DbService<T> : IDbService<T>
-        where T : BaseDbModel, new()
+    public class DbService : IDbService
     {
-        private readonly Client _supabaseClient;
+        private readonly DataContext _dataContext;
 
-        public DbService(Client supabaseClient)
+        public DbService(DataContext dataContext)
         {
-            _supabaseClient = supabaseClient;
+            _dataContext = dataContext;
         }
 
         /// <inheritdoc/>
-        public async Task<List<T>> GetAllAsync()
+        public async Task<List<Category>> GetAllCategories()
         {
-            var response = await _supabaseClient.From<T>().Get();
+            List<Category> categories = await _dataContext.Categories.ToListAsync();
 
-            if (response.Models == null || response.Models.Count == 0)
+            if (categories == null || categories.Count == 0)
             {
                 throw new NotFoundException();
             }
 
-            return response.Models;
+            return categories;
         }
 
         /// <inheritdoc/>
-        public async Task<T> GetAsync(int id)
+        public async Task<Category> GetCategory(int id)
         {
-            var response = await _supabaseClient.From<T>().Where(x => x.Id == id).Single();
+            Category category = await _dataContext.Categories.Where(x => x.Id == id).FirstAsync();
 
-            if (response == null)
+            if (category == null)
             {
                 throw new NotFoundException(id);
             }
 
-            return response;
+            return category;
         }
 
         /// <inheritdoc/>
-        public async Task<List<Category>> GetByCategoryAsync(int categoryTypeId)
+        public async Task<List<Category>> GetCategoriesByCategoryType(int categoryTypeId)
         {
-            var response = await _supabaseClient
-                .From<Category>()
-                .Where(x => x.TypeId == categoryTypeId)
-                .Get();
+            List<Category> categories = await _dataContext.Categories
+                .Where(x => x.CategoryTypeId == categoryTypeId)
+                .ToListAsync();
 
-            if (response.Models == null || response.Models.Count == 0)
+            if (categories == null || categories.Count == 0)
             {
                 throw new NotFoundException();
             }
 
-            return response.Models;
+            return categories;
+        }
+
+        /// <inheritdoc/>
+        public async Task<List<CategoryType>> GetAllCategoryTypes()
+        {
+            List<CategoryType> categorytypes = await _dataContext.CategoriesTypes.ToListAsync();
+
+            if (categorytypes == null || categorytypes.Count == 0)
+            {
+                throw new NotFoundException();
+            }
+
+            return categorytypes;
+        }
+
+        /// <inheritdoc/>
+        public async Task<CategoryType> GetCategoryType(int id)
+        {
+            CategoryType categoryType = await _dataContext.CategoriesTypes
+                .Where(x => x.Id == id)
+                .SingleAsync();
+
+            if (categoryType == null)
+            {
+                throw new NotFoundException(id);
+            }
+
+            return categoryType;
         }
     }
 }

--- a/Services/CategoryService/Db/IDbService.cs
+++ b/Services/CategoryService/Db/IDbService.cs
@@ -4,25 +4,36 @@ using Common.Models.Category;
 
 namespace CategoryService.Service
 {
-    public interface IDbService<T>
-        where T : BaseDbModel, new()
+    public interface IDbService
     {
         /// <summary>
         /// Retrieves all categories from the db
         /// </summary>
         /// <returns>Task with list of categories</returns>
-        Task<List<T>> GetAllAsync();
+        Task<List<Category>> GetAllCategories();
 
         /// <summary>
         /// Attempts to find a category using provided id
         /// </summary>
         /// <returns>Task with a category</returns>
-        Task<T> GetAsync(int id);
+        Task<Category> GetCategory(int id);
 
         /// <summary>
         /// Retrieves all categories of a given type from the db
         /// </summary>
         /// <returns>Task with list of categories</returns>
-        Task<List<Category>> GetByCategoryAsync(int categoryTypeId);
+        Task<List<Category>> GetCategoriesByCategoryType(int categoryTypeId);
+
+        /// <summary>
+        /// Retrieves all category types from the db
+        /// </summary>
+        /// <returns>Task with list of categories</returns>
+        Task<List<CategoryType>> GetAllCategoryTypes();
+
+        /// <summary>
+        /// Attempts to find a category type using provided id
+        /// </summary>
+        /// <returns>Task with a category</returns>
+        Task<CategoryType> GetCategoryType(int id);
     }
 }

--- a/Services/CategoryService/Program.cs
+++ b/Services/CategoryService/Program.cs
@@ -1,10 +1,6 @@
-using System;
+using CategoryService.Db;
 using CategoryService.Service;
-using Microsoft.AspNetCore.DataProtection.KeyManagement;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Supabase;
+using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -16,22 +12,14 @@ builder.Services.AddControllers().AddNewtonsoftJson();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
-// Supabase configuration
-var configuration = builder.Configuration;
-var supabaseUrl = configuration["SupaBase:Url"];
-var supabaseKey = configuration["SupaBase:Key"];
-builder.Services.AddSingleton(_ =>
+builder.Services.AddDbContext<DataContext>(options =>
 {
-    var options = new Supabase.SupabaseOptions { AutoConnectRealtime = true };
-
-    var client = new Supabase.Client(supabaseUrl!, supabaseKey, options);
-    client.InitializeAsync().Wait();
-
-    return client;
+    options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection"));
 });
 
 // Dependency injection
-builder.Services.AddScoped(typeof(IDbService<>), typeof(DbService<>));
+builder.Services.AddScoped<DataContext>();
+builder.Services.AddScoped<IDbService, DbService>();
 
 var app = builder.Build();
 

--- a/Services/CategoryService/appsettings.json
+++ b/Services/CategoryService/appsettings.json
@@ -5,9 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "SupaBase": {
-    "Url": "https://nwggvwbdgvdxgxkvpyvw.supabase.co",
-    "Key": ""
+  "ConnectionStrings": {
+    //Ask project administrator for a connection string
+    "DefaultConnection": ""
   },
   "AllowedHosts": "*"
 }

--- a/Tests/CategoryService.Test/CategoryController.Test.cs
+++ b/Tests/CategoryService.Test/CategoryController.Test.cs
@@ -13,7 +13,7 @@ namespace CategoryService.Test
     [TestClass]
     public class CategoryControllerTest
     {
-        Mock<IDbService<Category>> _mockDbService;
+        Mock<IDbService> _mockDbService;
 
         Category _category;
         List<Category> _categories;
@@ -21,12 +21,12 @@ namespace CategoryService.Test
         [TestInitialize]
         public void InitializeTest()
         {
-            _mockDbService = new Mock<IDbService<Category>>();
+            _mockDbService = new Mock<IDbService>();
 
             _category = new Category
             {
                 Id = 0,
-                TypeId = 0,
+                CategoryTypeId = 0,
                 Value = "Category One"
             };
 
@@ -36,7 +36,7 @@ namespace CategoryService.Test
         [TestMethod]
         public void GetAllTest()
         {
-            _mockDbService.Setup(x => x.GetAllAsync()).ReturnsAsync(_categories);
+            _mockDbService.Setup(x => x.GetAllCategories()).ReturnsAsync(_categories);
             CategoryController controller = new CategoryController(_mockDbService.Object);
 
             var response = controller.GetAll();
@@ -50,7 +50,7 @@ namespace CategoryService.Test
         [TestMethod]
         public void GetAllTestWithNotFoundException()
         {
-            _mockDbService.Setup(x => x.GetAllAsync()).Throws(new NotFoundException());
+            _mockDbService.Setup(x => x.GetAllCategories()).Throws(new NotFoundException());
             CategoryController controller = new CategoryController(_mockDbService.Object);
 
             var response = controller.GetAll();
@@ -64,7 +64,7 @@ namespace CategoryService.Test
         [TestMethod]
         public void GetAllTestWithInternalErrorException()
         {
-            _mockDbService.Setup(x => x.GetAllAsync()).Throws(new Exception());
+            _mockDbService.Setup(x => x.GetAllCategories()).Throws(new Exception());
             CategoryController controller = new CategoryController(_mockDbService.Object);
 
             var response = controller.GetAll();
@@ -79,7 +79,7 @@ namespace CategoryService.Test
         public void GetByTypeTest()
         {
             int id = 1;
-            _mockDbService.Setup(x => x.GetByCategoryAsync(id)).ReturnsAsync(_categories);
+            _mockDbService.Setup(x => x.GetCategoriesByCategoryType(id)).ReturnsAsync(_categories);
             CategoryController controller = new CategoryController(_mockDbService.Object);
 
             var response = controller.GetByType(id);
@@ -94,7 +94,7 @@ namespace CategoryService.Test
         public void GetByTypeTestWithNotFoundException()
         {
             int id = 1;
-            _mockDbService.Setup(x => x.GetByCategoryAsync(id)).Throws(new NotFoundException());
+            _mockDbService.Setup(x => x.GetCategoriesByCategoryType(id)).Throws(new NotFoundException());
             CategoryController controller = new CategoryController(_mockDbService.Object);
 
             var response = controller.GetByType(id);
@@ -109,7 +109,7 @@ namespace CategoryService.Test
         public void GetByTypeTestWithInternalErrorException()
         {
             int id = 1;
-            _mockDbService.Setup(x => x.GetByCategoryAsync(id)).Throws(new Exception());
+            _mockDbService.Setup(x => x.GetCategoriesByCategoryType(id)).Throws(new Exception());
             CategoryController controller = new CategoryController(_mockDbService.Object);
 
             var response = controller.GetByType(id);
@@ -124,7 +124,7 @@ namespace CategoryService.Test
         public void GetByIdTest()
         {
             int id = 1;
-            _mockDbService.Setup(x => x.GetAsync(id)).ReturnsAsync(_category);
+            _mockDbService.Setup(x => x.GetCategory(id)).ReturnsAsync(_category);
             CategoryController controller = new CategoryController(_mockDbService.Object);
 
             var response = controller.GetById(id);
@@ -139,7 +139,7 @@ namespace CategoryService.Test
         public void GetByIdTestWithNotFoundException()
         {
             int id = 1;
-            _mockDbService.Setup(x => x.GetAsync(id)).Throws(new NotFoundException());
+            _mockDbService.Setup(x => x.GetCategory(id)).Throws(new NotFoundException());
             CategoryController controller = new CategoryController(_mockDbService.Object);
 
             var response = controller.GetById(id);
@@ -154,7 +154,7 @@ namespace CategoryService.Test
         public void GetByIdTestWithInternalErrorException()
         {
             int id = 1;
-            _mockDbService.Setup(x => x.GetAsync(id)).Throws(new Exception());
+            _mockDbService.Setup(x => x.GetCategory(id)).Throws(new Exception());
             CategoryController controller = new CategoryController(_mockDbService.Object);
 
             var response = controller.GetById(id);

--- a/Tests/CategoryService.Test/CategoryTypeController.Test.cs
+++ b/Tests/CategoryService.Test/CategoryTypeController.Test.cs
@@ -13,7 +13,7 @@ namespace CategoryService.Test
     [TestClass]
     public class CategoryTypeControllerTest
     {
-        Mock<IDbService<CategoryType>> _mockDbService;
+        Mock<IDbService> _mockDbService;
 
         CategoryType _categoryType;
         List<CategoryType> _categoryTypes;
@@ -21,7 +21,7 @@ namespace CategoryService.Test
         [TestInitialize]
         public void InitializeTest()
         {
-            _mockDbService = new Mock<IDbService<CategoryType>>();
+            _mockDbService = new Mock<IDbService>();
 
             _categoryType = new CategoryType
             {
@@ -35,7 +35,7 @@ namespace CategoryService.Test
         [TestMethod]
         public void GetAllTest()
         {
-            _mockDbService.Setup(x => x.GetAllAsync()).ReturnsAsync(_categoryTypes);
+            _mockDbService.Setup(x => x.GetAllCategoryTypes()).ReturnsAsync(_categoryTypes);
             CategoryTypeController controller = new CategoryTypeController(_mockDbService.Object);
 
             var response = controller.GetAll();
@@ -49,7 +49,7 @@ namespace CategoryService.Test
         [TestMethod]
         public void GetAllTestWithNotFoundException()
         {
-            _mockDbService.Setup(x => x.GetAllAsync()).Throws(new NotFoundException());
+            _mockDbService.Setup(x => x.GetAllCategoryTypes()).Throws(new NotFoundException());
             CategoryTypeController controller = new CategoryTypeController(_mockDbService.Object);
 
             var response = controller.GetAll();
@@ -63,7 +63,7 @@ namespace CategoryService.Test
         [TestMethod]
         public void GetAllTestWithInternalErrorException()
         {
-            _mockDbService.Setup(x => x.GetAllAsync()).Throws(new Exception());
+            _mockDbService.Setup(x => x.GetAllCategoryTypes()).Throws(new Exception());
             CategoryTypeController controller = new CategoryTypeController(_mockDbService.Object);
 
             var response = controller.GetAll();
@@ -78,7 +78,7 @@ namespace CategoryService.Test
         public void GetByIdTest()
         {
             int id = 1;
-            _mockDbService.Setup(x => x.GetAsync(id)).ReturnsAsync(_categoryType);
+            _mockDbService.Setup(x => x.GetCategoryType(id)).ReturnsAsync(_categoryType);
             CategoryTypeController controller = new CategoryTypeController(_mockDbService.Object);
 
             var response = controller.GetById(id);
@@ -93,7 +93,7 @@ namespace CategoryService.Test
         public void GetByIdTestWithNotFoundException()
         {
             int id = 1;
-            _mockDbService.Setup(x => x.GetAsync(id)).Throws(new NotFoundException());
+            _mockDbService.Setup(x => x.GetCategoryType(id)).Throws(new NotFoundException());
             CategoryTypeController controller = new CategoryTypeController(_mockDbService.Object);
 
             var response = controller.GetById(id);
@@ -108,7 +108,7 @@ namespace CategoryService.Test
         public void GetByIdTestWithInternalErrorException()
         {
             int id = 1;
-            _mockDbService.Setup(x => x.GetAsync(id)).Throws(new Exception());
+            _mockDbService.Setup(x => x.GetCategoryType(id)).Throws(new Exception());
             CategoryTypeController controller = new CategoryTypeController(_mockDbService.Object);
 
             var response = controller.GetById(id);


### PR DESCRIPTION
Adjust the Categories Service to MSSQL instead of the supabase service.

The most significant changes involve a shift from using Supabase to Entity Framework Core for database operations. This is reflected in updates to the `DbService` class, `IDbService` interface, and the `Program.cs` and `appsettings.json` files. Additionally, the `Category` and `CategoryType` classes have been modified, removing certain attributes and renaming properties. The `BaseDbModel` class has also been updated, removing inheritance from `BaseModel` and the `PrimaryKey` attribute from the `Id` property. Lastly, the `CategoryController` and `CategoryTypeController` classes have been updated to use a non-generic `IDbService`.